### PR TITLE
Add initial support of state reasons

### DIFF
--- a/src/common/base/printer.rs
+++ b/src/common/base/printer.rs
@@ -12,6 +12,12 @@ pub enum PrinterState {
     UNKNOWN,
 }
 
+
+#[derive(Debug, Clone)]
+pub enum PrinterStateReason {
+    OFFLINE,
+}
+
 /**
  * Printer is a struct to representation the system printer
  */
@@ -75,6 +81,11 @@ pub struct Printer {
      * The state of the printer
      */
     pub state: PrinterState,
+
+    /**
+     * The state reasons of the printer
+     */
+    pub state_reasons: Vec<PrinterStateReason>,
 }
 
 impl Debug for Printer {
@@ -84,6 +95,7 @@ impl Debug for Printer {
             "Printer {{
                 \r  name: {:?},
                 \r  state: {:?},
+                \r  state_reasons: {:?},
                 \r  system_name: {:?},
                 \r  is_default: {:?},
                 \r  uri: {:?},
@@ -97,6 +109,7 @@ impl Debug for Printer {
             \r}}",
             self.name,
             self.state,
+            self.state_reasons,
             self.system_name,
             self.is_default,
             self.uri,
@@ -116,6 +129,7 @@ impl Clone for Printer {
         return Printer {
             name: self.name.clone(),
             state: self.state.clone(),
+            state_reasons: self.state_reasons.clone(),
             uri: self.uri.clone(),
             location: self.location.clone(),
             port_name: self.port_name.clone(),
@@ -145,6 +159,7 @@ impl Printer {
             processor: platform_printer.get_processor(),
             description: platform_printer.get_description(),
             state: PrinterState::from_platform_state(platform_printer.get_state().as_str()),
+            state_reasons: PrinterStateReason::from_platform_state(platform_printer.get_state_reasons()),
         };
 
         return printer;
@@ -184,6 +199,12 @@ impl Printer {
 impl PrinterState {
     pub(crate) fn from_platform_state(platform_state: &str) -> Self {
         return crate::Platform::parse_printer_state(platform_state);
+    }
+}
+
+impl PrinterStateReason {
+    pub(crate) fn from_platform_state(platform_state: Vec<String>) -> Vec<Self> {
+        return crate::Platform::parse_printer_state_reasons(platform_state);
     }
 }
 

--- a/src/common/traits/platform.rs
+++ b/src/common/traits/platform.rs
@@ -1,5 +1,8 @@
 use std::time::SystemTime;
-use crate::common::base::{job::PrinterJobState, printer::{Printer, PrinterState}};
+use crate::common::base::{
+    job::PrinterJobState, 
+    printer::{Printer, PrinterState, PrinterStateReason}
+};
 
 pub trait PlatformPrinterGetters {
     fn get_name(&self) -> String;
@@ -10,6 +13,7 @@ pub trait PlatformPrinterGetters {
     fn get_uri(&self) -> String;
     fn get_location(&self) -> String;
     fn get_state(&self) -> String;
+    fn get_state_reasons(&self) -> Vec<String>;
     fn get_port_name(&self) -> String;
     fn get_processor(&self) -> String;
     fn get_description(&self) -> String;
@@ -35,5 +39,6 @@ pub trait PlatformActions {
     fn get_default_printer() -> Option<Printer>;
     fn get_printer_by_name(printer_name: &str) -> Option<Printer>;
     fn parse_printer_state(platform_state: &str) -> PrinterState;
+    fn parse_printer_state_reasons(platform_state_reasons: Vec<String>) -> Vec<PrinterStateReason>;
     fn parse_printer_job_state(platform_state: u64) -> PrinterJobState;
 }

--- a/src/unix/cups/dests.rs
+++ b/src/unix/cups/dests.rs
@@ -97,6 +97,10 @@ impl PlatformPrinterGetters for CupsDestT {
         return self.get_option("printer-state");
     }
 
+    fn get_state_reasons(&self) -> Vec<String> {
+        return self.get_option("printer-state-reasons").split(',').map(|x| x.to_string()).collect();
+    }
+
     fn get_port_name(&self) -> String {
         return self.get_option("device-uri");
     }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -4,7 +4,7 @@ use std::str;
 use crate::common::{
     base::{
         job::{PrinterJob, PrinterJobState},
-        printer::{Printer, PrinterState},
+        printer::{Printer, PrinterState, PrinterStateReason},
     },
     traits::platform::{PlatformActions, PlatformPrinterGetters},
 };
@@ -91,6 +91,20 @@ impl PlatformActions for crate::Platform {
         }
 
         return PrinterState::UNKNOWN;
+    }
+
+    fn parse_printer_state_reasons(platform_state_reasons: Vec<String>) -> Vec<PrinterStateReason> {
+        let mut vec_printer_state_reasons = Vec::new();
+        
+        // TODO: implement other status
+        // https://www.rfc-editor.org/rfc/rfc2911#section-4.4.12
+        // https://stackoverflow.com/questions/44687154/more-complete-list-of-cups-printer-state-reasons
+        
+        if platform_state_reasons.contains(&"offline-report".to_string()) {
+            vec_printer_state_reasons.push(PrinterStateReason::OFFLINE);
+        }
+
+        return vec_printer_state_reasons;
     }
 
     fn parse_printer_job_state(platform_state: u64) -> PrinterJobState {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -88,6 +88,11 @@ impl PlatformActions for crate::Platform {
 
         return PrinterState::UNKNOWN;
     }
+    
+    fn parse_printer_state_reasons(platform_state_reasons: Vec<String>) -> Vec<PrinterStateReason> {
+        // TODO: Implement. Refer https://learn.microsoft.com/en-us/windows/win32/printdocs/printer-info-6#members
+        return vec![];
+    }
 
     fn parse_printer_job_state(platform_state: u64) -> PrinterJobState {
         if platform_state == 32

--- a/src/windows/winspool/info.rs
+++ b/src/windows/winspool/info.rs
@@ -86,6 +86,10 @@ impl PlatformPrinterGetters for PRINTER_INFO_2W {
     fn get_state(&self) -> String {
         return self.Status.to_string();
     }
+    fn get_state_reasons(&self) -> Vec<String> {
+        // TODO: Implement
+        return vec![];
+    }
     fn get_port_name(&self) -> String {
         return wchar_t_to_string(self.pPortName);
     }


### PR DESCRIPTION
Closes #34 

This adds a very minimum support of `Printer.state_reasons`.
I confirmed `OFFLINE` reason is added to `Printer.state_reasons` when printers are offline.

Winspool seems to offer a similar mechanism, but not implemented in this PR since I do not have Windows PC...

