### PR TITLE
Add GetPrintersOptions so "shared duplex printers" can be included 

### DIFF
--- a/src/common/base/get_printers_options.rs
+++ b/src/common/base/get_printers_options.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Default, Clone)]
+pub struct GetPrintersOptions {
+    // Set to true to exclude printers that is shared and can print both sides of a sheet of paper
+    pub exclude_shared_duplex_printer: bool,
+}

--- a/src/common/base/mod.rs
+++ b/src/common/base/mod.rs
@@ -1,2 +1,3 @@
 pub mod job;
 pub mod printer;
+pub mod get_printers_options;

--- a/src/common/traits/platform.rs
+++ b/src/common/traits/platform.rs
@@ -1,3 +1,4 @@
+use crate::common::base::get_printers_options::GetPrintersOptions;
 use std::time::SystemTime;
 use crate::common::base::{job::PrinterJobState, printer::{Printer, PrinterState}};
 
@@ -28,6 +29,7 @@ pub trait PlatformPrinterJobGetters {
 }
 
 pub trait PlatformActions {
+    fn get_printers_with_opt(options: GetPrintersOptions) -> Vec<Printer>;
     fn get_printers() -> Vec<Printer>;
     fn print(printer_system_name: &str, buffer: &[u8], job_name: Option<&str>) -> Result<(), &'static str>;    
     fn print_file(printer_system_name: &str, file_path: &str, job_name: Option<&str>) -> Result<(), &'static str>;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,6 +1,7 @@
 use cups::dests::get_dests;
 use std::str;
 
+use crate::common::base::get_printers_options::GetPrintersOptions;
 use crate::common::{
     base::{
         job::{PrinterJob, PrinterJobState},
@@ -14,10 +15,14 @@ mod utils;
 
 impl PlatformActions for crate::Platform {
     fn get_printers() -> Vec<Printer> {
+        Self::get_printers_with_opt(GetPrintersOptions::default())
+    }
+
+    fn get_printers_with_opt(options: GetPrintersOptions) -> Vec<Printer> {
         let dests = cups::dests::get_dests().unwrap_or_default();
         let printers = dests
             .into_iter()
-            .filter(|p| !p.is_shared_duplex())
+            .filter(|p| !options.exclude_shared_duplex_printer || !p.is_shared_duplex())
             .map(|p| Printer::from_platform_printer_getters(p))
             .collect();
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::common::base::get_printers_options::GetPrintersOptions;
 use crate::common::base::job::PrinterJobState;
 use crate::common::base::printer::PrinterState;
 use crate::common::base::{job::PrinterJob, printer::Printer};
@@ -10,10 +11,15 @@ mod winspool;
 
 impl PlatformActions for crate::Platform {
     fn get_printers() -> Vec<Printer> {
+        Self::get_printers_with_opt(GetPrintersOptions::default())
+    }
+
+    fn get_printers_with_opt(options: GetPrintersOptions) -> Vec<Printer> {
         let data = winspool::info::enum_printers(None);
 
         let printers: Vec<Printer> = data
             .iter()
+            // TODO: Support exclude_shared_duplex_printer
             .filter(|p| !p.pPrinterName.is_null())
             .map(|p| Printer::from_platform_printer_getters(p))
             .collect();


### PR DESCRIPTION
Closes #36 

- By default, "shared duplex printer" (I assume it is a shared printer that can print duplex) is now included. Because, exclusion was surprising to me.
- If `exclude_shared_duplex_printer` is set to `true`, shared duplex printers are excluded. 