### PR TITLE
Allow to pass options & return job ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ let printers = get_printers();
 **Create print job of an byte array**
 
 ```rust
-printer.print("42".as_bytes());
-// Result<(), &'static str>
+let job_id = printer.print("42".as_bytes(), None, &[]);
+// Result<ia32, &'static str>
 ```
 
 **Create print job of an file**
 
 ```rust
-printer.print_file("my_file/example/path.txt");
-// Result<(), &'static str>
+let job_id = printer.print_file("my_file/example/path.txt", None, &[]);
+// Result<ia32, &'static str>
 ```
 
 **Get a printer by name**
@@ -71,14 +71,19 @@ fn main() {
     // Get a printer by the name
     let my_printer = get_printer_by_name("my_printer");
     if my_printer.is_some() {
-        my_printer.unwrap().print_file("notes.txt", None);
+        my_printer.unwrap().print_file("notes.txt", None, &[]);
         // Err("") or Ok(())
     }
 
     // Use the default printer
     let default_printer = get_default_printer();
     if default_printer.is_some() {
-        default_printer.unwrap().print("dlrow olleh".as_bytes(), Some("My Job"));
+        // options are currently UNIX-only. see https://www.cups.org/doc/options.html
+        let options = [
+            ("document-format", "application/vnd.cups-raw"),
+            ("copies", "2"),
+        ];
+        default_printer.unwrap().print("dlrow olleh".as_bytes(), Some("My Job"), &options);
         // Ok(())
     }
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ let printers = get_printers();
 
 ```rust
 let job_id = printer.print("42".as_bytes(), None, &[]);
-// Result<ia32, &'static str>
+// Result<u64, &'static str>
 ```
 
 **Create print job of an file**
 
 ```rust
 let job_id = printer.print_file("my_file/example/path.txt", None, &[]);
-// Result<ia32, &'static str>
+// Result<u64, &'static str>
 ```
 
 **Get a printer by name**

--- a/src/common/base/printer.rs
+++ b/src/common/base/printer.rs
@@ -153,14 +153,14 @@ impl Printer {
     /**
      * Print bytes with self printer instance
      */
-    pub fn print(&self, buffer: &[u8], job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str> {
+    pub fn print(&self, buffer: &[u8], job_name: Option<&str>, options: &[(&str, &str)]) -> Result<u64, &'static str> {
         return crate::Platform::print(self.system_name.as_str(), buffer, job_name, options);
     }
 
     /**
      * Print specific file with self printer instance
      */
-    pub fn print_file(&self, file_path: &str, job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str> {
+    pub fn print_file(&self, file_path: &str, job_name: Option<&str>, options: &[(&str, &str)]) -> Result<u64, &'static str> {
         return crate::Platform::print_file(self.system_name.as_str(), file_path, job_name, options);
     }
     

--- a/src/common/base/printer.rs
+++ b/src/common/base/printer.rs
@@ -153,15 +153,15 @@ impl Printer {
     /**
      * Print bytes with self printer instance
      */
-    pub fn print(&self, buffer: &[u8], job_name: Option<&str>) -> Result<(), &'static str> {
-        return crate::Platform::print(self.system_name.as_str(), buffer, job_name);
+    pub fn print(&self, buffer: &[u8], job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str> {
+        return crate::Platform::print(self.system_name.as_str(), buffer, job_name, options);
     }
 
     /**
      * Print specific file with self printer instance
      */
-    pub fn print_file(&self, file_path: &str, job_name: Option<&str>) -> Result<(), &'static str> {
-        return crate::Platform::print_file(self.system_name.as_str(), file_path, job_name);
+    pub fn print_file(&self, file_path: &str, job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str> {
+        return crate::Platform::print_file(self.system_name.as_str(), file_path, job_name, options);
     }
     
     /**

--- a/src/common/traits/platform.rs
+++ b/src/common/traits/platform.rs
@@ -29,8 +29,8 @@ pub trait PlatformPrinterJobGetters {
 
 pub trait PlatformActions {
     fn get_printers() -> Vec<Printer>;
-    fn print(printer_system_name: &str, buffer: &[u8], job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str>;    
-    fn print_file(printer_system_name: &str, file_path: &str, job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str>;
+    fn print(printer_system_name: &str, buffer: &[u8], job_name: Option<&str>, options: &[(&str, &str)]) -> Result<u64, &'static str>;    
+    fn print_file(printer_system_name: &str, file_path: &str, job_name: Option<&str>, options: &[(&str, &str)]) -> Result<u64, &'static str>;
     fn get_printer_jobs(printer_name: &str, active_only: bool) -> Vec<crate::common::base::job::PrinterJob>;
     fn get_default_printer() -> Option<Printer>;
     fn get_printer_by_name(printer_name: &str) -> Option<Printer>;

--- a/src/common/traits/platform.rs
+++ b/src/common/traits/platform.rs
@@ -29,8 +29,8 @@ pub trait PlatformPrinterJobGetters {
 
 pub trait PlatformActions {
     fn get_printers() -> Vec<Printer>;
-    fn print(printer_system_name: &str, buffer: &[u8], job_name: Option<&str>) -> Result<(), &'static str>;    
-    fn print_file(printer_system_name: &str, file_path: &str, job_name: Option<&str>) -> Result<(), &'static str>;
+    fn print(printer_system_name: &str, buffer: &[u8], job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str>;    
+    fn print_file(printer_system_name: &str, file_path: &str, job_name: Option<&str>, options: &[(&str, &str)]) -> Result<i32, &'static str>;
     fn get_printer_jobs(printer_name: &str, active_only: bool) -> Vec<crate::common::base::job::PrinterJob>;
     fn get_default_printer() -> Option<Printer>;
     fn get_printer_by_name(printer_name: &str) -> Option<Printer>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,18 +17,23 @@
 //!    // Get a printer by the name
 //!    let my_printer = get_printer_by_name("my_printer");
 //!    if my_printer.is_some() {
-//!        my_printer.unwrap().print_file("notes.txt", None);
-//!        // Err("cupsPrintFile failed")
+//!        my_printer.unwrap().print_file("notes.txt", None, &[]);
+//!        // Err("cupsPrintFile failed") or Ok(())
 //!    }
 //!
 //!    // Use the default printer
 //!    let default_printer = get_default_printer();
 //!    if default_printer.is_some() {
-//!        default_printer.unwrap().print("dlrow olleh".as_bytes(), Some("My Job"));
+//!        // options are currently UNIX-only. see https://www.cups.org/doc/options.html
+//!        let options = [
+//!            ("document-format", "application/vnd.cups-raw"),
+//!            ("copies", "2"),
+//!        ];
+//!        default_printer.unwrap().print("dlrow olleh".as_bytes(), Some("My Job"), &options);
 //!        // Ok(())
-//!    }
+//!   }
 //!
-//! }
+//!}
 //! ```
 //!
 //!
@@ -72,7 +77,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_cups_options() {
+    fn test_zpl_with_cups_options() {
         //println!("{:?}", get_printers());
         let printer = get_printer_by_name("Zebra Technologies ZTC ZD410-203dpi ZPL").unwrap();
         let zpl = "^XA~TA000~JSN^LT0^MNW^MTD^PON^PMN^LH0,0^JMA^PR6,6~SD15^JUS^LRN^CI27^XZ
@@ -89,6 +94,33 @@ mod tests {
             ("document-format", "application/vnd.cups-raw"),
             ("copies", "2"),
         ];
+        let job_id = printer.print(zpl.as_bytes(), Some("My ZPL Job"), &options);
+        println!("Job ID: {:?}", job_id);
+        // println!("{:?}", printer.get_job_history());
+        assert!(job_id.is_ok());
+    }
+}
+
+#[cfg(target_family = "windows")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zpl_with_win_options() {
+        //println!("{:?}", get_printers());
+        let printer = get_printer_by_name("Microsoft Print to PDF").unwrap();
+        let zpl = "^XA~TA000~JSN^LT0^MNW^MTD^PON^PMN^LH0,0^JMA^PR6,6~SD15^JUS^LRN^CI27^XZ
+^XA
+^MMT
+^PW399
+^LL0216
+^LS0
+^FT50,85^A0N,24,20^FH^FDID: 1234^FS
+^FT50,60^A0N,24,20^FH^FDLast name: Doe^FS
+^FT50,35^A0N,24,20^FH^FDFirst name: John^FS
+^PQ1,0,1,Y^XZ";
+        let options = []; // currently no options are supported with Windows
         let job_id = printer.print(zpl.as_bytes(), Some("My ZPL Job"), &options);
         println!("Job ID: {:?}", job_id);
         // println!("{:?}", printer.get_job_history());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,3 +65,33 @@ pub fn get_printer_by_name(printer_name: &str) -> Option<Printer> {
 pub fn get_default_printer() -> Option<Printer> {
     return Platform::get_default_printer();
 }
+
+#[cfg(target_family = "unix")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cups_options() {
+        //println!("{:?}", get_printers());
+        let printer = get_printer_by_name("Zebra Technologies ZTC ZD410-203dpi ZPL").unwrap();
+        let zpl = "^XA~TA000~JSN^LT0^MNW^MTD^PON^PMN^LH0,0^JMA^PR6,6~SD15^JUS^LRN^CI27^XZ
+^XA
+^MMT
+^PW399
+^LL0216
+^LS0
+^FT50,85^A0N,24,20^FH^FDID: 1234^FS
+^FT50,60^A0N,24,20^FH^FDLast name: Doe^FS
+^FT50,35^A0N,24,20^FH^FDFirst name: John^FS
+^PQ1,0,1,Y^XZ";
+        let options = [
+            ("document-format", "application/vnd.cups-raw"),
+            ("copies", "2"),
+        ];
+        let job_id = printer.print(zpl.as_bytes(), Some("My ZPL Job"), &options);
+        println!("Job ID: {:?}", job_id);
+        // println!("{:?}", printer.get_job_history());
+        assert!(job_id.is_ok());
+    }
+}

--- a/src/unix/cups/jobs.rs
+++ b/src/unix/cups/jobs.rs
@@ -1,9 +1,13 @@
-use std::{slice, time::SystemTime};
-use libc::{c_char, c_int, time_t};
 use crate::{
     common::traits::platform::PlatformPrinterJobGetters,
-    unix::utils::{date::time_t_to_system_time, strings::{c_char_to_string, str_to_cstring}},
+    unix::utils::{
+        date::time_t_to_system_time,
+        strings::{c_char_to_string, str_to_cstring},
+    },
 };
+use libc::{c_char, c_int, time_t};
+use std::ffi::CString;
+use std::{slice, time::SystemTime};
 
 #[link(name = "cups")]
 extern "C" {
@@ -12,8 +16,9 @@ extern "C" {
         printer_name: *const c_char,
         filename: *const c_char,
         title: *const c_char,
-        options: i32,
-    ) -> i32;
+        num_options: c_int,
+        options: *const CupsOptionT,
+    ) -> c_int;
 
     fn cupsGetJobs(
         jobs: *mut *mut CupsJobsS,
@@ -23,6 +28,13 @@ extern "C" {
         whichjobs: c_int,
     ) -> c_int;
 
+}
+
+#[derive(Debug)]
+#[repr(C)]
+struct CupsOptionT {
+    name: *const c_char,
+    value: *const c_char,
 }
 
 #[derive(Debug)]
@@ -43,35 +55,35 @@ pub struct CupsJobsS {
 
 impl PlatformPrinterJobGetters for CupsJobsS {
     fn get_id(&self) -> u64 {
-       return self.id as u64;
+        self.id as u64
     }
 
     fn get_name(&self) -> String {
-        return c_char_to_string(self.title);
+        c_char_to_string(self.title)
     }
 
     fn get_state(&self) -> u64 {
-        return self.state as u64;
+        self.state as u64
     }
 
     fn get_printer(&self) -> String {
-        return c_char_to_string(self.dest);
+        c_char_to_string(self.dest)
     }
 
     fn get_media_type(&self) -> String {
-        return c_char_to_string(self.format);
+        c_char_to_string(self.format)
     }
 
     fn get_created_at(&self) -> SystemTime {
-        return time_t_to_system_time(self.creation_time).unwrap();
+        time_t_to_system_time(self.creation_time).unwrap()
     }
 
     fn get_processed_at(&self) -> Option<SystemTime> {
-        return time_t_to_system_time(self.processing_time);
+        time_t_to_system_time(self.processing_time)
     }
 
     fn get_completed_at(&self) -> Option<SystemTime> {
-        return time_t_to_system_time(self.completed_time);
+        time_t_to_system_time(self.completed_time)
     }
 }
 
@@ -83,30 +95,66 @@ pub fn get_printer_jobs(printer_name: &str, active_only: bool) -> Option<&'stati
     let whichjobs = if active_only { 0 } else { -1 };
     let name = str_to_cstring(printer_name);
 
-    return unsafe {
+    unsafe {
         let jobs_count = cupsGetJobs(&mut jobs_ptr, name.as_ptr(), 0, whichjobs);
         if jobs_count > 0 {
             Some(slice::from_raw_parts(jobs_ptr, jobs_count as usize))
         } else {
             None
         }
-    };
+    }
 }
 
 /**
- * Send an file to printer
+ * Send a file to the printer
  */
-pub fn print_file(printer_name: &str, file_path: &str, job_name: Option<&str>) -> Result<(), &'static str> {
-    unsafe {        
+pub fn print_file(
+    printer_name: &str,
+    file_path: &str,
+    job_name: Option<&str>,
+    options: &[(&str, &str)],
+) -> Result<i32, &'static str> {
+    unsafe {
         let printer = &str_to_cstring(printer_name);
         let filename = str_to_cstring(file_path);
         let title = str_to_cstring(job_name.unwrap_or(file_path));
- 
-        let result = cupsPrintFile(printer.as_ptr(), filename.as_ptr(), title.as_ptr(), 0);
-        return if result == 0 {
+
+        // You ensure those heap-allocated strings:
+        // - Stay in memory
+        // - Are not dropped
+        // - Live through the entire FFI call
+        // Then, when print_file() ends, the cstrings Vec is dropped after the FFI call is done, so memory cleanup happens safely.
+        let mut cstrings: Vec<CString> = Vec::with_capacity(options.len() * 2);
+
+        let mut cup_opts: Vec<CupsOptionT> = Vec::with_capacity(options.len());
+
+        for (key, value) in options.iter() {
+            let c_key = str_to_cstring(key);
+            let c_value = str_to_cstring(value);
+            cup_opts.push(CupsOptionT {
+                name: c_key.as_ptr(),
+                value: c_value.as_ptr(),
+            });
+            cstrings.push(c_key);
+            cstrings.push(c_value);
+        }
+
+        let result = cupsPrintFile(
+            printer.as_ptr(),
+            filename.as_ptr(),
+            title.as_ptr(),
+            cup_opts.len() as c_int,
+            if cup_opts.is_empty() {
+                std::ptr::null()
+            } else {
+                cup_opts.as_ptr()
+            },
+        );
+
+        if result == 0 {
             Err("cupsPrintFile failed")
         } else {
-            Ok(())
+            Ok(result)
         }
     }
 }

--- a/src/unix/cups/jobs.rs
+++ b/src/unix/cups/jobs.rs
@@ -113,7 +113,7 @@ pub fn print_file(
     file_path: &str,
     job_name: Option<&str>,
     options: &[(&str, &str)],
-) -> Result<i32, &'static str> {
+) -> Result<u64, &'static str> {
     unsafe {
         let printer = &str_to_cstring(printer_name);
         let filename = str_to_cstring(file_path);
@@ -154,7 +154,7 @@ pub fn print_file(
         if result == 0 {
             Err("cupsPrintFile failed")
         } else {
-            Ok(result)
+            Ok(result as u64)
         }
     }
 }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -30,7 +30,7 @@ impl PlatformActions for crate::Platform {
         buffer: &[u8],
         job_name: Option<&str>,
         options: &[(&str, &str)],
-    ) -> Result<i32, &'static str> {
+    ) -> Result<u64, &'static str> {
         let path = crate::unix::utils::file::save_tmp_file(buffer);
         return if path.is_some() {
             let file_path = path.unwrap();
@@ -45,7 +45,7 @@ impl PlatformActions for crate::Platform {
         file_path: &str,
         job_name: Option<&str>,
         options: &[(&str, &str)],
-    ) -> Result<i32, &'static str> {
+    ) -> Result<u64, &'static str> {
         return cups::jobs::print_file(printer_system_name, file_path, job_name, options);
     }
 

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -29,11 +29,12 @@ impl PlatformActions for crate::Platform {
         printer_system_name: &str,
         buffer: &[u8],
         job_name: Option<&str>,
-    ) -> Result<(), &'static str> {
+        options: &[(&str, &str)],
+    ) -> Result<i32, &'static str> {
         let path = crate::unix::utils::file::save_tmp_file(buffer);
         return if path.is_some() {
             let file_path = path.unwrap();
-            return Self::print_file(printer_system_name, file_path.to_str().unwrap(), job_name);
+            return Self::print_file(printer_system_name, file_path.to_str().unwrap(), job_name, options);
         } else {
             Err("Failed to create temp file")
         };
@@ -43,8 +44,9 @@ impl PlatformActions for crate::Platform {
         printer_system_name: &str,
         file_path: &str,
         job_name: Option<&str>,
-    ) -> Result<(), &'static str> {
-        return cups::jobs::print_file(printer_system_name, file_path, job_name);
+        options: &[(&str, &str)],
+    ) -> Result<i32, &'static str> {
+        return cups::jobs::print_file(printer_system_name, file_path, job_name, options);
     }
 
     fn get_printer_jobs(printer_name: &str, active_only: bool) -> Vec<PrinterJob> {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -26,19 +26,21 @@ impl PlatformActions for crate::Platform {
         printer_system_name: &str,
         buffer: &[u8],
         job_name: Option<&str>,
-    ) -> Result<(), &'static str> {
-        return winspool::jobs::print_buffer(printer_system_name, job_name, buffer);
+        options: &[(&str, &str)],
+    ) -> Result<i32, &'static str> {
+        return winspool::jobs::print_buffer(printer_system_name, job_name, buffer, options);
     }
 
     fn print_file(
         printer_system_name: &str,
         file_path: &str,
         job_name: Option<&str>,
-    ) -> Result<(), &'static str> {
+        options: &[(&str, &str)],
+    ) -> Result<i32, &'static str> {
         let buffer = utils::file::get_file_as_bytes(file_path);
         return if buffer.is_some() {
             let job_name = job_name.unwrap_or(Path::new(file_path).file_name().unwrap().to_str().unwrap());
-            return Self::print(printer_system_name, &buffer.unwrap(), Some(job_name));
+            return Self::print(printer_system_name, &buffer.unwrap(), Some(job_name), options);
         } else {
             Err("failed to read file")
         };

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -27,7 +27,7 @@ impl PlatformActions for crate::Platform {
         buffer: &[u8],
         job_name: Option<&str>,
         options: &[(&str, &str)],
-    ) -> Result<i32, &'static str> {
+    ) -> Result<u64, &'static str> {
         return winspool::jobs::print_buffer(printer_system_name, job_name, buffer, options);
     }
 
@@ -36,7 +36,7 @@ impl PlatformActions for crate::Platform {
         file_path: &str,
         job_name: Option<&str>,
         options: &[(&str, &str)],
-    ) -> Result<i32, &'static str> {
+    ) -> Result<u64, &'static str> {
         let buffer = utils::file::get_file_as_bytes(file_path);
         return if buffer.is_some() {
             let job_name = job_name.unwrap_or(Path::new(file_path).file_name().unwrap().to_str().unwrap());

--- a/src/windows/winspool/info.rs
+++ b/src/windows/winspool/info.rs
@@ -107,11 +107,13 @@ pub fn enum_printers(name: Option<&str>) -> &'static [PRINTER_INFO_2W] {
     let mut bytes_needed: c_ulong = 0;
     let mut count_printers: c_ulong = 0;
     let mut buffer_ptr: *mut PRINTER_INFO_2W = ptr::null_mut();
-    let name_ptr = if name.is_none() {
-        ptr::null_mut()
-    } else {
-        str_to_wide_string(name.unwrap()).as_ptr()
-    } as *const wchar_t;
+
+    // Store wide name in a variable so it lives long enough
+    let name_wide: Option<Vec<u16>> = name.map(str_to_wide_string);
+    let name_ptr = match &name_wide {
+        Some(vec) => vec.as_ptr(),
+        None => ptr::null(),
+    };
 
     for _ in 0..2 {
         let result = unsafe {

--- a/src/windows/winspool/jobs.rs
+++ b/src/windows/winspool/jobs.rs
@@ -149,7 +149,7 @@ pub fn print_buffer(
     job_name: Option<&str>,
     buffer: &[u8],
     _options: &[(&str, &str)], // currently unused
-) -> Result<i32, &'static str> {
+) -> Result<u64, &'static str> {
     unsafe {
         let printer_name = str_to_wide_string(printer_system_name);
         let mut printer_handle: *mut c_void = ptr::null_mut();
@@ -200,11 +200,7 @@ pub fn print_buffer(
             return Err("WritePrinter failed")
         }
 
-        Ok(if job_id <= i32::MAX as u32 {
-            job_id as i32
-        } else {
-            0
-        })
+        Ok(job_id as u64)
     }
 }
 

--- a/src/windows/winspool/jobs.rs
+++ b/src/windows/winspool/jobs.rs
@@ -148,7 +148,8 @@ pub fn print_buffer(
     printer_system_name: &str,
     job_name: Option<&str>,
     buffer: &[u8],
-) -> Result<(), &'static str> {
+    options: &[(&str, &str)], // currently unused
+) -> Result<i32, &'static str> {
     unsafe {
         let printer_name = str_to_wide_string(printer_system_name);
         let mut printer_handle: *mut c_void = ptr::null_mut();
@@ -197,9 +198,13 @@ pub fn print_buffer(
         if write_result == 0 {
             return Err("WritePrinter failed");
         }
-    }
 
-    return Ok(());
+        if write_result == 0 {
+            Err("WritePrinter failed")
+        } else {
+            Ok(result)
+        }
+    }
 }
 
 /**

--- a/src/windows/winspool/jobs.rs
+++ b/src/windows/winspool/jobs.rs
@@ -148,7 +148,7 @@ pub fn print_buffer(
     printer_system_name: &str,
     job_name: Option<&str>,
     buffer: &[u8],
-    options: &[(&str, &str)], // currently unused
+    _options: &[(&str, &str)], // currently unused
 ) -> Result<i32, &'static str> {
     unsafe {
         let printer_name = str_to_wide_string(printer_system_name);
@@ -172,7 +172,8 @@ pub fn print_buffer(
             pOutputFile: ptr::null_mut(),
         };
 
-        if StartDocPrinterW(printer_handle, 1, &doc_info) == 0 {
+        let job_id = StartDocPrinterW(printer_handle, 1, &doc_info);
+        if job_id == 0 {
             ClosePrinter(printer_handle);
             return Err("StartDocPrinterW failed");
         }
@@ -196,14 +197,14 @@ pub fn print_buffer(
         ClosePrinter(printer_handle);
 
         if write_result == 0 {
-            return Err("WritePrinter failed");
+            return Err("WritePrinter failed")
         }
 
-        if write_result == 0 {
-            Err("WritePrinter failed")
+        Ok(if job_id <= i32::MAX as u32 {
+            job_id as i32
         } else {
-            Ok(result)
-        }
+            0
+        })
     }
 }
 


### PR DESCRIPTION
on UNIX these are CUPS options, on Windows this feature is currently unused (no-op).

make the print functions return the job ID.

fixes #39 