### PR TITLE
feat(windows): Support print options via DEVMODE

### DIFF
--- a/src/common/base.rs
+++ b/src/common/base.rs
@@ -1,3 +1,4 @@
+pub mod devmode;
 pub mod errors;
 pub mod job;
 pub mod options;

--- a/src/common/base/devmode.rs
+++ b/src/common/base/devmode.rs
@@ -1,0 +1,159 @@
+/// Maps a paper size name to a Windows DMPAPER_* constant value.
+///
+/// Accepts standard paper size names (case-insensitive) or numeric IDs.
+/// Returns `None` if the value is not recognized.
+pub fn parse_paper_size(value: &str) -> Option<i16> {
+    Some(match value.to_ascii_uppercase().as_str() {
+        "LETTER" => 1,
+        "LETTERSMALL" => 2,
+        "TABLOID" => 3,
+        "LEDGER" => 4,
+        "LEGAL" => 5,
+        "EXECUTIVE" => 7,
+        "A3" => 8,
+        "A4" => 9,
+        "A4SMALL" => 10,
+        "A5" => 11,
+        "B4" | "B4_JIS" => 12,
+        "B5" | "B5_JIS" => 13,
+        _ => return value.parse().ok(),
+    })
+}
+
+/// Maps a media source / input slot name to a Windows DMBIN_* constant value.
+///
+/// Accepts standard tray names (case-insensitive) or numeric IDs.
+/// Returns `None` if the value is not recognized.
+pub fn parse_media_source(value: &str) -> Option<i16> {
+    Some(match value.to_ascii_uppercase().as_str() {
+        "AUTO" => 7,
+        "UPPER" | "TRAY1" | "ONLYONE" => 1,
+        "LOWER" | "TRAY2" => 2,
+        "MIDDLE" | "TRAY3" => 3,
+        "MANUAL" => 4,
+        "ENVELOPE" => 5,
+        "ENVMANUAL" => 6,
+        "TRACTOR" => 8,
+        "SMALLFMT" => 9,
+        "LARGEFMT" => 10,
+        "LARGECAPACITY" => 11,
+        "CASSETTE" => 14,
+        "FORMSOURCE" => 15,
+        _ => return value.parse().ok(),
+    })
+}
+
+/// Maps a color model name to a Windows DMCOLOR_* constant value.
+///
+/// Returns `None` if the value is not recognized.
+pub fn parse_color_model(value: &str) -> Option<i16> {
+    Some(match value.to_ascii_uppercase().as_str() {
+        "GRAY" | "MONOCHROME" => 1,
+        "COLOR" => 2,
+        _ => return value.parse().ok(),
+    })
+}
+
+/// Maps a duplex / sides name to a Windows DMDUP_* constant value.
+///
+/// Returns `None` if the value is not recognized.
+pub fn parse_duplex(value: &str) -> Option<i16> {
+    Some(match value.to_ascii_uppercase().as_str() {
+        "ONE-SIDED" | "SIMPLEX" => 1,
+        "TWO-SIDED-LONG-EDGE" => 2,
+        "TWO-SIDED-SHORT-EDGE" => 3,
+        _ => return value.parse().ok(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_paper_size_named() {
+        assert_eq!(parse_paper_size("A4"), Some(9));
+        assert_eq!(parse_paper_size("a4"), Some(9));
+        assert_eq!(parse_paper_size("A3"), Some(8));
+        assert_eq!(parse_paper_size("A5"), Some(11));
+        assert_eq!(parse_paper_size("B4"), Some(12));
+        assert_eq!(parse_paper_size("B5"), Some(13));
+        assert_eq!(parse_paper_size("B4_JIS"), Some(12));
+        assert_eq!(parse_paper_size("B5_JIS"), Some(13));
+        assert_eq!(parse_paper_size("Letter"), Some(1));
+        assert_eq!(parse_paper_size("LEGAL"), Some(5));
+        assert_eq!(parse_paper_size("EXECUTIVE"), Some(7));
+        assert_eq!(parse_paper_size("TABLOID"), Some(3));
+        assert_eq!(parse_paper_size("LEDGER"), Some(4));
+    }
+
+    #[test]
+    fn test_parse_paper_size_numeric() {
+        assert_eq!(parse_paper_size("9"), Some(9));
+        assert_eq!(parse_paper_size("13"), Some(13));
+        assert_eq!(parse_paper_size("256"), Some(256));
+    }
+
+    #[test]
+    fn test_parse_paper_size_invalid() {
+        assert_eq!(parse_paper_size("UNKNOWN"), None);
+        assert_eq!(parse_paper_size(""), None);
+        assert_eq!(parse_paper_size("abc"), None);
+    }
+
+    #[test]
+    fn test_parse_media_source_named() {
+        assert_eq!(parse_media_source("Auto"), Some(7));
+        assert_eq!(parse_media_source("AUTO"), Some(7));
+        assert_eq!(parse_media_source("Tray1"), Some(1));
+        assert_eq!(parse_media_source("Tray2"), Some(2));
+        assert_eq!(parse_media_source("Tray3"), Some(3));
+        assert_eq!(parse_media_source("UPPER"), Some(1));
+        assert_eq!(parse_media_source("LOWER"), Some(2));
+        assert_eq!(parse_media_source("MIDDLE"), Some(3));
+        assert_eq!(parse_media_source("MANUAL"), Some(4));
+        assert_eq!(parse_media_source("ENVELOPE"), Some(5));
+        assert_eq!(parse_media_source("CASSETTE"), Some(14));
+        assert_eq!(parse_media_source("ONLYONE"), Some(1));
+    }
+
+    #[test]
+    fn test_parse_media_source_numeric() {
+        assert_eq!(parse_media_source("7"), Some(7));
+        assert_eq!(parse_media_source("1"), Some(1));
+        assert_eq!(parse_media_source("256"), Some(256));
+    }
+
+    #[test]
+    fn test_parse_media_source_invalid() {
+        assert_eq!(parse_media_source("UNKNOWN"), None);
+        assert_eq!(parse_media_source(""), None);
+        assert_eq!(parse_media_source("xyz"), None);
+    }
+
+    #[test]
+    fn test_parse_color_model() {
+        assert_eq!(parse_color_model("Gray"), Some(1));
+        assert_eq!(parse_color_model("gray"), Some(1));
+        assert_eq!(parse_color_model("Monochrome"), Some(1));
+        assert_eq!(parse_color_model("Color"), Some(2));
+        assert_eq!(parse_color_model("color"), Some(2));
+        assert_eq!(parse_color_model("1"), Some(1));
+        assert_eq!(parse_color_model("2"), Some(2));
+        assert_eq!(parse_color_model("UNKNOWN"), None);
+        assert_eq!(parse_color_model(""), None);
+    }
+
+    #[test]
+    fn test_parse_duplex() {
+        assert_eq!(parse_duplex("one-sided"), Some(1));
+        assert_eq!(parse_duplex("simplex"), Some(1));
+        assert_eq!(parse_duplex("two-sided-long-edge"), Some(2));
+        assert_eq!(parse_duplex("two-sided-short-edge"), Some(3));
+        assert_eq!(parse_duplex("1"), Some(1));
+        assert_eq!(parse_duplex("2"), Some(2));
+        assert_eq!(parse_duplex("3"), Some(3));
+        assert_eq!(parse_duplex("UNKNOWN"), None);
+        assert_eq!(parse_duplex(""), None);
+    }
+}

--- a/src/windows/winspool/jobs.rs
+++ b/src/windows/winspool/jobs.rs
@@ -1,11 +1,21 @@
 #![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 
-use libc::{c_int, c_ulong, c_ushort, c_void, wchar_t};
-use std::{ffi::c_char, ptr, slice};
+use libc::{c_int, c_short, c_ulong, c_ushort, c_void, wchar_t};
+use std::{
+    alloc::{Layout, alloc, dealloc},
+    ffi::c_char,
+    ptr, slice,
+};
 
 use crate::{
-    common::{base::errors::PrintersError, traits::platform::PlatformPrinterJobGetters},
+    common::{
+        base::{
+            devmode::{parse_color_model, parse_duplex, parse_media_source, parse_paper_size},
+            errors::PrintersError,
+        },
+        traits::platform::PlatformPrinterJobGetters,
+    },
     windows::utils::{
         date::{calculate_system_time, get_current_epoch},
         memory::alloc_s,
@@ -52,6 +62,14 @@ unsafe extern "system" {
         pJob: *mut c_char,
         Command: c_ulong,
     ) -> c_int;
+    fn DocumentPropertiesW(
+        hWnd: *mut c_void,
+        hPrinter: *mut c_void,
+        pDeviceName: *const wchar_t,
+        pDevModeOutput: *mut c_void,
+        pDevModeInput: *mut c_void,
+        fMode: c_ulong,
+    ) -> c_int;
 }
 
 #[repr(C)]
@@ -66,6 +84,67 @@ struct DocInfo1 {
     pDocName: *mut wchar_t,
     pOutputFile: *mut wchar_t,
     pDatatype: *mut wchar_t,
+}
+
+// DEVMODE field flags
+const DM_PAPERSIZE: c_ulong = 0x00000002;
+const DM_PAPERLENGTH: c_ulong = 0x00000004;
+const DM_PAPERWIDTH: c_ulong = 0x00000008;
+const DM_COPIES: c_ulong = 0x00000100;
+const DM_DEFAULTSOURCE: c_ulong = 0x00000200;
+const DM_COLOR: c_ulong = 0x00000800;
+const DM_DUPLEX: c_ulong = 0x00001000;
+
+// DocumentPropertiesW fMode
+const DM_OUT_BUFFER: c_ulong = 2;
+
+// OpenPrinterW access rights
+const PRINTER_ACCESS_USE: c_ulong = 0x00000008;
+
+/**
+ * The DEVMODEW structure contains information about the initialization and environment of a printer.
+ * https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-devmodew
+ *
+ * Only the printer-relevant fields (union printer variant) are declared.
+ */
+#[repr(C)]
+struct DEVMODEW {
+    dmDeviceName: [wchar_t; 32],
+    dmSpecVersion: c_ushort,
+    dmDriverVersion: c_ushort,
+    dmSize: c_ushort,
+    dmDriverExtra: c_ushort,
+    dmFields: c_ulong,
+    // Union: printer variant
+    dmOrientation: c_short,
+    dmPaperSize: c_short,
+    dmPaperLength: c_short,
+    dmPaperWidth: c_short,
+    dmScale: c_short,
+    dmCopies: c_short,
+    dmDefaultSource: c_short,
+    dmPrintQuality: c_short,
+    // After union
+    dmColor: c_short,
+    dmDuplex: c_short,
+    dmYResolution: c_short,
+    dmTTOption: c_short,
+    dmCollate: c_short,
+    dmFormName: [wchar_t; 32],
+    dmLogPixels: c_ushort,
+    dmBitsPerPel: c_ulong,
+    dmPelsWidth: c_ulong,
+    dmPelsHeight: c_ulong,
+    dmDisplayFlags: c_ulong,
+    dmDisplayFrequency: c_ulong,
+    dmICMMethod: c_ulong,
+    dmICMIntent: c_ulong,
+    dmMediaType: c_ulong,
+    dmDitherType: c_ulong,
+    dmReserved1: c_ulong,
+    dmReserved2: c_ulong,
+    dmPanningWidth: c_ulong,
+    dmPanningHeight: c_ulong,
 }
 
 /**
@@ -150,17 +229,93 @@ impl PlatformPrinterJobGetters for JOB_INFO_1W {
 }
 
 /**
- * Open printer utility
+ * Get the default DEVMODE for a printer via DocumentPropertiesW.
+ * Returns the DEVMODE pointer and its Layout for deallocation.
+ */
+unsafe fn get_printer_devmode(
+    printer_name: &str,
+) -> Result<(*mut DEVMODEW, Layout), PrintersError> {
+    let handle = open_printer(printer_name)?;
+    let wide_name = str_to_wide_string(printer_name);
+
+    let size = unsafe {
+        DocumentPropertiesW(
+            ptr::null_mut(),
+            handle,
+            wide_name.as_ptr() as *const wchar_t,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            0,
+        )
+    };
+
+    if size < 0 {
+        unsafe { ClosePrinter(handle) };
+        return Err(PrintersError::print_error(
+            "DocumentPropertiesW failed to get buffer size",
+        ));
+    }
+
+    let layout = Layout::from_size_align(size as usize, align_of::<DEVMODEW>()).map_err(|_| {
+        unsafe { ClosePrinter(handle) };
+        PrintersError::print_error("Failed to create DEVMODE layout")
+    })?;
+
+    let devmode = unsafe { alloc(layout) } as *mut DEVMODEW;
+
+    let result = unsafe {
+        DocumentPropertiesW(
+            ptr::null_mut(),
+            handle,
+            wide_name.as_ptr() as *const wchar_t,
+            devmode as *mut c_void,
+            ptr::null_mut(),
+            DM_OUT_BUFFER,
+        )
+    };
+
+    unsafe { ClosePrinter(handle) };
+
+    if result < 0 {
+        unsafe { dealloc(devmode as *mut u8, layout) };
+        return Err(PrintersError::print_error(
+            "DocumentPropertiesW failed to get DEVMODE",
+        ));
+    }
+
+    Ok((devmode, layout))
+}
+
+/**
+ * Open a printer, optionally with a DEVMODE applied via PRINTER_DEFAULTS.
  */
 fn open_printer(printer_name: &str) -> Result<*mut c_void, PrintersError> {
+    open_printer_with_devmode(printer_name, None)
+}
+
+fn open_printer_with_devmode(
+    printer_name: &str,
+    devmode: Option<*mut DEVMODEW>,
+) -> Result<*mut c_void, PrintersError> {
     let printer_name = str_to_wide_string(printer_name);
     let mut printer_handle: *mut c_void = ptr::null_mut();
+
+    let mut defaults = devmode.map(|dm| PrinterDefaultW {
+        pDatatype: ptr::null_mut(),
+        pDevMode: dm as *mut c_void,
+        DesiredAccess: PRINTER_ACCESS_USE,
+    });
+
+    let p_defaults = match defaults.as_mut() {
+        Some(d) => d as *mut PrinterDefaultW,
+        None => ptr::null_mut(),
+    };
 
     return if unsafe {
         OpenPrinterW(
             printer_name.as_ptr() as *const wchar_t,
             &mut printer_handle,
-            ptr::null_mut(),
+            p_defaults,
         )
     } == 0
     {
@@ -171,7 +326,19 @@ fn open_printer(printer_name: &str) -> Result<*mut c_void, PrintersError> {
 }
 
 /**
- * Print a buffer as RAW datatype with winspool WritePrinterx
+ * Print a buffer with winspool WritePrinter.
+ *
+ * Supported raw_properties:
+ * - "copies"          : number of copies (numeric string)
+ * - "document-format" : data type (default "RAW")
+ * - "ColorModel"      : "Gray" | "Color"
+ * - "sides"           : "one-sided" | "two-sided-long-edge" | "two-sided-short-edge"
+ * - "PageSize"/"media": paper size name (e.g. "A4", "B5", "Letter") or numeric DMPAPER_* id
+ * - "PageWidth"/"media-width": custom paper width in 1/10 mm (e.g. "1480" for 148mm)
+ * - "PageHeight"/"media-height": custom paper height in 1/10 mm (e.g. "2100" for 210mm)
+ * - "InputSlot"/"media-source": tray name (e.g. "Auto", "Tray1", "Tray2") or numeric DMBIN_* id
+ *
+ * Note: When both PageWidth and PageHeight are specified, they take precedence over PageSize.
  */
 pub fn print_buffer(
     printer_name: &str,
@@ -180,18 +347,85 @@ pub fn print_buffer(
     options: &[(&str, &str)],
 ) -> Result<u64, PrintersError> {
     unsafe {
-        let printer_handle = open_printer(printer_name)?;
-
-        let mut copies = 1;
+        let mut copies: u32 = 1;
         let mut data_type = "RAW";
+
+        let mut dm_paper_size: Option<c_short> = None;
+        let mut dm_paper_width: Option<c_short> = None;
+        let mut dm_paper_length: Option<c_short> = None;
+        let mut dm_default_source: Option<c_short> = None;
+        let mut dm_duplex: Option<c_short> = None;
+        let mut dm_color: Option<c_short> = None;
 
         for option in options {
             match option.0 {
                 "copies" => copies = option.1.parse().unwrap_or(copies),
                 "document-format" => data_type = option.1,
+                "ColorModel" => dm_color = parse_color_model(option.1),
+                "sides" => dm_duplex = parse_duplex(option.1),
+                "PageSize" | "media" => dm_paper_size = parse_paper_size(option.1),
+                "InputSlot" | "media-source" => dm_default_source = parse_media_source(option.1),
+                "PageWidth" | "media-width" => {
+                    dm_paper_width = option.1.parse::<c_short>().ok();
+                }
+                "PageHeight" | "media-height" => {
+                    dm_paper_length = option.1.parse::<c_short>().ok();
+                }
                 _ => {}
             }
         }
+
+        // Custom paper size: width and height must both be specified
+        let has_custom_size = dm_paper_width.is_some() && dm_paper_length.is_some();
+
+        let has_devmode_options = dm_paper_size.is_some()
+            || has_custom_size
+            || dm_default_source.is_some()
+            || dm_duplex.is_some()
+            || dm_color.is_some();
+
+        // Try to apply DEVMODE if any driver-level options were specified
+        let devmode_state = if has_devmode_options {
+            match get_printer_devmode(printer_name) {
+                Ok((devmode, layout)) => {
+                    macro_rules! apply {
+                        ($value:expr, $field:ident, $flag:expr) => {
+                            if let Some(v) = $value {
+                                (*devmode).$field = v;
+                                (*devmode).dmFields |= $flag;
+                            }
+                        };
+                    }
+                    if has_custom_size {
+                        // Custom size: clear dmPaperSize, set width and length
+                        (*devmode).dmPaperSize = 0;
+                        (*devmode).dmFields |= DM_PAPERSIZE;
+                        apply!(dm_paper_width, dmPaperWidth, DM_PAPERWIDTH);
+                        apply!(dm_paper_length, dmPaperLength, DM_PAPERLENGTH);
+                    } else {
+                        apply!(dm_paper_size, dmPaperSize, DM_PAPERSIZE);
+                    }
+                    apply!(dm_default_source, dmDefaultSource, DM_DEFAULTSOURCE);
+                    apply!(dm_duplex, dmDuplex, DM_DUPLEX);
+                    apply!(dm_color, dmColor, DM_COLOR);
+                    (*devmode).dmCopies = copies as c_short;
+                    (*devmode).dmFields |= DM_COPIES;
+                    Some((devmode, layout))
+                }
+                Err(_) => None, // Fall back to legacy behavior
+            }
+        } else {
+            None
+        };
+
+        let devmode_ptr = devmode_state.as_ref().map(|(dm, _)| *dm);
+        let printer_handle = match open_printer_with_devmode(printer_name, devmode_ptr) {
+            Ok(handle) => handle,
+            Err(e) => {
+                free_devmode(devmode_state);
+                return Err(e);
+            }
+        };
 
         let mut p_data_type = str_to_wide_string(data_type);
         let mut p_doc_name =
@@ -206,10 +440,15 @@ pub fn print_buffer(
         let job_id = StartDocPrinterW(printer_handle, 1, &doc_info);
         if job_id == 0 {
             ClosePrinter(printer_handle);
+            free_devmode(devmode_state);
             return Err(PrintersError::job_error("StartDocPrinterW failed"));
         }
 
-        for _ in 0..copies {
+        // When DEVMODE is active, copies are handled by the driver (dmCopies).
+        // Otherwise, fall back to writing the buffer multiple times.
+        let write_count = if devmode_state.is_some() { 1 } else { copies };
+
+        for _ in 0..write_count {
             if StartPagePrinter(printer_handle) != 0 {
                 let mut bytes_written: c_ulong = 0;
                 WritePrinter(
@@ -224,8 +463,16 @@ pub fn print_buffer(
 
         EndDocPrinter(printer_handle);
         ClosePrinter(printer_handle);
+        free_devmode(devmode_state);
 
         Ok(job_id as u64)
+    }
+}
+
+/// Free a DEVMODE buffer if present.
+unsafe fn free_devmode(state: Option<(*mut DEVMODEW, Layout)>) {
+    if let Some((devmode, layout)) = state {
+        unsafe { dealloc(devmode as *mut u8, layout) };
     }
 }
 


### PR DESCRIPTION
## Summary

- Added DEVMODE-based print option support for print_buffer on Windows
- Previously, only `copies` and `document-format` were effective; `ColorModel`, `sides`, etc. were silently ignored
- Retrieves the printer's default DEVMODE via DocumentPropertiesW, modifies fields based on options, and passes it to OpenPrinterW


### Supported options

raw_property key | DEVMODE field | Example values
---|---|---
ColorModel | dmColor | Gray, Color
sides | dmDuplex  | one-sided, two-sided-long-edge, two-sided-short-edge
PageSize / media | dmPaperSize | A4, B5, Letter, numeric ID or `Custom.148x200mm`,
InputSlot / media-source | dmDefaultSource | Auto, Tray1, Tray2, or numeric ID
copies | dmCopies | numeric string 

## Notes

- Fallbacks to legacy behavior (no DEVMODE) if DocumentPropertiesW fails (e.g. virtual printers)
- Parse functions (parse_paper_size, etc.) are placed in common/base/devmode.rs for platform-independent unit testing
- No changes to the CUPS/Unix side — it already passes options directly to cupsPrintFile

