### PR TITLE
feat: add mswinpr2 direct print support for Windows

### DIFF
--- a/src/common/converters.rs
+++ b/src/common/converters.rs
@@ -42,6 +42,9 @@ impl GhostscriptConverterOptions {
     pub fn pngmono() -> Self {
         Self::from_device("pngmono")
     }
+    pub fn mswinpr2() -> Self {
+        Self::from_device("mswinpr2")
+    }
     pub fn from_device(device: &'static str) -> Self {
         Self {
             dpi: None,
@@ -69,6 +72,58 @@ impl Converter {
         match self {
             Converter::Ghostscript(options) => ghostscript::convert(buffer, options),
             Converter::None => Ok(buffer.to_vec()),
+        }
+    }
+
+    /**
+     * Returns true if this converter prints directly to the printer (e.g. mswinpr2)
+     * bypassing the winspool RAW data path.
+     */
+    pub fn is_direct_print(&self) -> bool {
+        matches!(
+            self,
+            Converter::Ghostscript(GhostscriptConverterOptions {
+                device: Some("mswinpr2"),
+                ..
+            })
+        )
+    }
+
+    /**
+     * Directly print a file to a printer using Ghostscript mswinpr2 device.
+     * This bypasses the winspool RAW path and renders via GDI.
+     */
+    pub fn direct_print_file(
+        &self,
+        printer_system_name: &str,
+        file_path: &str,
+    ) -> Result<u64, PrintersError> {
+        match self {
+            Converter::Ghostscript(options) if options.device == Some("mswinpr2") => {
+                ghostscript::direct_print_file(options, printer_system_name, file_path)
+            }
+            _ => Err(PrintersError::print_error(
+                "direct_print_file is only supported with mswinpr2 device",
+            )),
+        }
+    }
+
+    /**
+     * Directly print a byte buffer to a printer using Ghostscript mswinpr2 device.
+     * Writes the buffer to a temporary file and prints it.
+     */
+    pub fn direct_print_buffer(
+        &self,
+        printer_system_name: &str,
+        buffer: &[u8],
+    ) -> Result<u64, PrintersError> {
+        match self {
+            Converter::Ghostscript(options) if options.device == Some("mswinpr2") => {
+                ghostscript::direct_print_buffer(options, printer_system_name, buffer)
+            }
+            _ => Err(PrintersError::print_error(
+                "direct_print_buffer is only supported with mswinpr2 device",
+            )),
         }
     }
 }

--- a/src/common/converters/ghostscript.rs
+++ b/src/common/converters/ghostscript.rs
@@ -3,6 +3,71 @@ use std::process::{Command, Stdio};
 
 use crate::common::{base::errors::PrintersError, converters::GhostscriptConverterOptions};
 
+fn gs_command(options: &GhostscriptConverterOptions) -> Command {
+    Command::new(match options.command {
+        Some(v) => v,
+        #[cfg(target_family = "unix")]
+        None => "gs",
+        #[cfg(target_family = "windows")]
+        None => "gswin64c.exe",
+    })
+}
+
+pub fn direct_print_file(
+    options: &GhostscriptConverterOptions,
+    printer_system_name: &str,
+    file_path: &str,
+) -> Result<u64, PrintersError> {
+    let output_file = format!("%printer%{printer_system_name}");
+    let mut command = gs_command(options);
+
+    command.args([
+        "-dBATCH",
+        "-dNOPAUSE",
+        "-sDEVICE=mswinpr2",
+        &format!("-sOutputFile={output_file}"),
+    ]);
+
+    if let Some(dpi) = options.dpi {
+        command.arg(format!("-r{dpi}"));
+    }
+
+    command.arg(file_path);
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let output = command.output().map_err(PrintersError::print_error)?;
+
+    if output.status.success() {
+        Ok(0)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(PrintersError::print_error(format!(
+            "Ghostscript mswinpr2 exit with code {}: {stderr}",
+            output.status.code().unwrap_or(1)
+        )))
+    }
+}
+
+pub fn direct_print_buffer(
+    options: &GhostscriptConverterOptions,
+    printer_system_name: &str,
+    buffer: &[u8],
+) -> Result<u64, PrintersError> {
+    let temp_dir = std::env::temp_dir();
+    let temp_file = temp_dir.join(format!("printers_mswinpr2_{}.pdf", std::process::id()));
+    std::fs::write(&temp_file, buffer).map_err(PrintersError::file_error)?;
+
+    let result = direct_print_file(
+        options,
+        printer_system_name,
+        temp_file.to_str().unwrap_or(""),
+    );
+
+    let _ = std::fs::remove_file(&temp_file);
+    result
+}
+
 pub fn convert(
     buffer: &[u8],
     options: &GhostscriptConverterOptions,

--- a/src/common/converters/ghostscript.rs
+++ b/src/common/converters/ghostscript.rs
@@ -29,9 +29,9 @@ pub fn direct_print_file(
         &format!("-sOutputFile={output_file}"),
     ]);
 
-    if let Some(dpi) = options.dpi {
-        command.arg(format!("-r{dpi}"));
-    }
+    // NOTE: mswinpr2 does NOT support -r for resolution control.
+    // Callers should pre-rasterize the input if DPI control is needed.
+    // See: https://ghostscript.readthedocs.io/en/latest/Devices.html#ms-windows-printers
 
     command.arg(file_path);
     command.stdout(Stdio::piped());

--- a/src/common/converters/ghostscript.rs
+++ b/src/common/converters/ghostscript.rs
@@ -24,6 +24,7 @@ pub fn direct_print_file(
     command.args([
         "-dBATCH",
         "-dNOPAUSE",
+        "-dNoCancel", // Case-sensitive. Hide the progress dialog
         "-sDEVICE=mswinpr2",
         &format!("-sOutputFile={output_file}"),
     ]);

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -30,6 +30,12 @@ impl PlatformActions for crate::Platform {
         buffer: &[u8],
         options: PrinterJobOptions,
     ) -> Result<u64, PrintersError> {
+        if options.converter.is_direct_print() {
+            return options
+                .converter
+                .direct_print_buffer(printer_system_name, buffer);
+        }
+
         let buffer = options.converter.convert(buffer)?;
         let buffer = &buffer.as_slice();
 
@@ -46,6 +52,12 @@ impl PlatformActions for crate::Platform {
         file_path: &str,
         options: PrinterJobOptions,
     ) -> Result<u64, PrintersError> {
+        if options.converter.is_direct_print() {
+            return options
+                .converter
+                .direct_print_file(printer_system_name, file_path);
+        }
+
         let buffer = file::get_file_as_bytes(file_path)?;
         Self::print(printer_system_name, &buffer, options)
     }


### PR DESCRIPTION
On Windows, the existing Ghostscript converters (ps2write, png16m, etc) convert PDF to an intermediate format (PostScript, PNG, TIFF) and sent it as RAW data via Winspool.
However, non-PostScript printers (like relatively-old home inkjet printers or label printers) can not interpret RAW PostScript/image bytes, so they silently discard the data.

[mswinpr2 device](https://ghostscript.readthedocs.io/en/latest/Devices.html#ms-windows-printers) can bypass Winspool RAW entirely -- Ghostscript renders through GDI, which goes through the printer driver.
The printer driver converts it into the printer's native format (PCL, ESC/P, or such proprietary raster command), so it basically works with any Windows printer.

I confirmed this worked with my app and printer.